### PR TITLE
Adding the needed MacOS brew install wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Using [Homebrew](https://brew.sh/), install XQuartz, socat, and the GNU version 
 brew cask install xquartz
 brew install socat
 brew install gnu-getopt
+brew install wget
 ```
 Then **restart your session** (or reboot) and, install the `run-mtgo` script:
 ```


### PR DESCRIPTION
Hey - I am on MacOS and I hit the same thing as found in https://github.com/pauleve/docker-mtgo/issues/13 (I think)

I fixed it by 'brew install wget'.  Now MTGO installer is launching and running and it'll probably work just like it did for that fellow.

I updated your instructions here which I think you probably just forgot to do. 

Thanks a lot for doing this!!