### PR TITLE
Change shebang to `/usr/bin/env bash`

### DIFF
--- a/run-mtgo
+++ b/run-mtgo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 defaultcmd="mtgo"
 


### PR DESCRIPTION
Problem: `run-mtgo` script doesn't run on some modern Linux distros like NixOS
Solution: fix shebang from deprecated `/bin/bash` to modern `/usr/bin/env bash`. 