### PR TITLE
fix: add winbind and libGL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update \
         ca-certificates \
         curl \
         cabextract \
+        ffmpeg \
+        libgl1-mesa-glx \
+        winbind \
     && apt autoremove -y --purge \
     && apt clean -y && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
`ffmpeg` and `libgl1-mesa-glx` to address missing lib
> 0294:err:wgl:init_opengl Failed to load libGL: libGL.so.1: cannot open shared object file: No such file or directory
> 0294:err:wgl:init_opengl OpenGL support is disabled.

`winbind` to make it shut up about NTLM
> 02b8:err:winediag:check_version ntlm_auth was not found or is outdated. Make sure that ntlm_auth >= 3.0.25 is in your path. Usually, you can find it in the winbind package of your distribution.
> 02b8:err:ntlm:ntlm_LsaApInitializePackage no NTLM support, expect problems