### PR TITLE
Add calibri and tahoma fonts to wine when building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && apt clean -y && rm -rf /var/lib/apt/lists/*
 
 RUN su - $WINE_USER -c 'wineboot -i' \
-    && su - $WINE_USER -c 'winetricks -q corefonts' \
+    && su - $WINE_USER -c 'winetricks -q corefonts calibri tahoma' \
     && su - $WINE_USER -c 'taskset -c 0 winetricks -f -q dotnet48' \
     && su - $WINE_USER -c 'winetricks win7 sound=alsa ddr=gdi'\
     && su - $WINE_USER -c 'winetricks renderer=gdi'\


### PR DESCRIPTION
Hi! I just switched over to this docker image after getting too frustrated with running MTGO in a VM. Thanks so much for making this!

I played around with some of the extra fonts wine can install, and found that adding these two fonts makes MTGO look more like it does on Windows. 

Attached are a couple screenshots showing the difference.

before
![mtgo-before](https://github.com/pauleve/docker-mtgo/assets/6841705/3dbc4a97-377e-49eb-8328-e440ada4b5cb)

after
![mtgo-after](https://github.com/pauleve/docker-mtgo/assets/6841705/f3b0b898-bee6-430d-86b2-ab191e70fa3c)