### PR TITLE
Update wine to 9.14-wow64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM panard/wine:9.8-wow64
+FROM panard/wine:9.14-wow64
 CMD mtgo
 
 ENV WINE_USER wine


### PR DESCRIPTION
Updates wine to 9.14-wow64 using Docker image from https://github.com/pauleve/docker-wine-wow64

```
./run-mtgo --update --test panard/mtgo:pr<#ID>
```