### PR TITLE
Make sound work under wine by patching the MTGO client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN wineboot -i \
 ENV WINEDEBUG -all,err+all,warn+chain,warn+cryptnet
 
 COPY extra/mtgo.sh /usr/local/bin/mtgo
+COPY extra/mtgo-audio-patch.py /usr/local/bin/mtgo-audio-patch
 
 ADD --chown=wine:wine https://mtgo.patch.daybreakgames.com/patch/mtg/live/client/setup.exe?v=8 /opt/mtgo/mtgo.exe
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,19 @@ validate: push tag
 
 .PHONY: sound
 sound:
-	$(DOCKER) build -t panard/mtgo:sound sound/
+	$(DOCKER) build --build-arg BASE=$(BASE) -t panard/mtgo:sound sound/
+
+try-sound:
+	./run-mtgo --sound panard/mtgo:sound
+
+# sound image on top of the published base image (no full rebuild)
+LOCALBASE=panard/mtgo:latest
+sound-local:
+	$(DOCKER) build --build-arg BASE=$(LOCALBASE) -t panard/mtgo:sound-base sound/
+	$(DOCKER) build -f sound/local.Dockerfile -t panard/mtgo:sound-local .
+
+try-sound-local:
+	./run-mtgo --sound panard/mtgo:sound-local
 
 push-sound:
 	$(DOCKER) push panard/mtgo:sound

--- a/README.md
+++ b/README.md
@@ -75,10 +75,52 @@ Depending on your configuration, you may want to adjust the resolution of the ga
 It will launch a configuration tool prior to launching MTGO. There you may be interested in the Graphics tab and use settings like this:
 ![](https://private-user-images.githubusercontent.com/228657/289696255-36af1dee-bea0-4363-93af-0d9c7bc849a0.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTAzMjI1MDUsIm5iZiI6MTcxMDMyMjIwNSwicGF0aCI6Ii8yMjg2NTcvMjg5Njk2MjU1LTM2YWYxZGVlLWJlYTAtNDM2My05M2FmLTBkOWM3YmM4NDlhMC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwMzEzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDMxM1QwOTMwMDVaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT00YzAwOGE1YmJlM2Q3OWZhYmM0ZTg5N2Q3MmNjZmQ3MTM4NDY5Yjk0ZjJiMGI1YjNmN2VkNjNhMGU2NjRmZjMyJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.AmIjIl49KCDxX8juEb5wrT_e7CAZ2PogzpPlvDlC5z4)
 
-Sound is disabled by default, but adventurous users can give a try to
+### Sound
+
+Sound is disabled by default.  To enable it:
 ```
 ./run-mtgo --sound
 ```
+Until the patched image is published, build it locally on top of the image you
+already use, and name it explicitly (`--sound` alone pulls the image from the
+hub):
+```
+make sound-local
+./run-mtgo --sound panard/mtgo:sound-local
+```
+This uses the `panard/mtgo:sound` image, which talks to the PulseAudio (or
+PipeWire) server of the host, and patches the audio code of your local MTGO
+installation, because the client's own audio path does not work under wine
+(see [#217](https://github.com/pauleve/docker-mtgo/issues/217)):
+
+* MTGO refuses to play anything when the Windows master volume reads as 0,
+  which is what wine reports;
+* MTGO enumerates WASAPI audio sessions through `ISimpleAudioVolume`, which
+  wine does not implement;
+* every sound is converted by the Media Foundation resampler, which wine does
+  not provide, and MTGO disables its audio for the whole session on the first
+  such failure.
+
+[SOUND.md](./SOUND.md) documents the whole mechanism, the evidence behind each
+patch and how to update it when a client release breaks it.
+
+The patch is applied to the copy of the client stored in your docker volume,
+right before MTGO starts, and again whenever the client updates itself (in that
+case sound comes back at the next start).  The original files are backed up in
+`AppData/Local/mtgo-audio-patch` inside the volume, and the MTGO volume sliders
+keep working.  Related options:
+
+```
+./run-mtgo --sound --no-audio-patch   # leave the client untouched
+./run-mtgo --sound --force-volume     # always play at 100%, ignore MTGO sliders
+```
+
+To undo the patch (for instance to check whether a client update fixed things
+upstream):
+```
+./run-mtgo --cmd 'mtgo-audio-patch --restore'
+```
+
 do not hesitate to report issues.
 
 To ensure running the latest docker image, use
@@ -114,6 +156,13 @@ You need to logout/login for the changes to take effect.
 ```
 docker kill mtgo_running
 ```
+
+* no sound, and `--sound` prints `this MTGO version is not supported by the
+audio patch`:
+
+the audio patch recognises the code it has to rewrite; if MTGO restructures it,
+the patch refuses to touch the client rather than corrupting it.  Please report
+it, mentioning the client version.
 
 
 ## FAQ

--- a/SOUND.md
+++ b/SOUND.md
@@ -1,0 +1,340 @@
+# Sound: how it works, and how to fix it when it breaks
+
+MTGO's audio code does not work under wine.  The `--sound` option therefore does
+two things: it wires the container to the host sound server, and it rewrites a
+few methods of the MTGO client installed in your docker volume.  This document
+describes the whole mechanism, the evidence behind each patch, and how to
+re-derive the patches when a client update invalidates them.
+
+Origin: <https://github.com/pauleve/docker-mtgo/issues/217>.  That issue
+contains a working recipe based on hardcoded file offsets for one specific
+build of `SharedResources.dll`; the implementation here locates the same code
+through metadata and code patterns instead, so it survives client updates.
+
+Last verified: MTGO `3.4.158.4691` (and `3.4.157.4686`), image based on
+`panard/mtgo:latest` (wine 9.8), PipeWire on the host.
+
+## Quick start
+
+```
+make sound-local                              # sound image + patch, on top of panard/mtgo:latest
+./run-mtgo --sound panard/mtgo:sound-local    # patches the client, then starts MTGO
+sound/tests/verify-audio.sh                   # proves audio works, without logging in
+```
+
+## The sound path
+
+```
+host PipeWire/PulseAudio server
+  └─ /run/user/<uid>/pulse/native      bind mounted by run-mtgo (--sound)
+      └─ /etc/pulse/client.conf        from sound/, points at the socket, disables shm+autospawn
+          └─ wine winmm, HKCU\Software\Wine\Drivers\Audio = "pulse"
+              └─ NAudio WaveOutEvent   (NAudio.WinMM.dll, shipped by MTGO)
+                  └─ MixingSampleProvider   one per MTGO sound queue
+                      └─ VolumeSampleProvider ← RawSourceWaveStream ← Audio/**/*.wav
+```
+
+Inside the client (`SharedResources.dll`), `Shiny.Utilities.AudioManager` is a
+static class that owns four `SoundQueue` instances (UI, Card, InDuel, Alerts).
+Each queue owns a `MixingSampleProvider` and a `WaveOutEvent`; each sound played
+becomes an `ActiveSample` added to the queue's mixer.  When audio works you see
+exactly four PulseAudio streams named `Magic Online`, `float32le 2ch 44100Hz`.
+
+`gstreamer` and `wmp=builtin` (installed by the sound image and by
+`extra/mtgo.sh`) are *not* involved in these sounds: MTGO reads the wav files
+itself and feeds raw PCM to NAudio.
+
+## Why it did not work
+
+Three independent failures, all confirmed by running MTGO's own code in the
+container (see [Verifying](#verifying)):
+
+### 1. The master volume reads as 0, so nothing is ever played
+
+`AudioManager.PlaySound()` starts with:
+
+```
+  IL_0008: ldc.i4.s        54
+  IL_000a: call            GetVolume (this assembly)      // MTGO's own slider
+  IL_0010: ldarg.1
+  IL_0011: ldc.r8          0.0
+  IL_001a: ble.s           -> IL_0038                     // sample volume <= 0 → return
+  IL_001c: call            GetWindowsVolume (this assembly)
+  IL_0021: ldc.r8          0.0
+  IL_002a: ble.s           -> IL_0038                     // windows volume <= 0 → return
+```
+
+and `GetWindowsVolume()` is
+
+```
+  IL_0000: call            IsMuted (this assembly)
+  IL_0005: brfalse.s       -> IL_0011
+  IL_0007: ldc.r8          0.0
+  IL_0010: ret
+  IL_0011: ldsfld          System.IntPtr::Zero
+  IL_0016: ldloca.s        0
+  IL_0018: call            waveOutGetVolume (this assembly)   // winmm P/Invoke
+  IL_001d: pop                                                // return code ignored
+  IL_001e: ldloc.0                                            // ... local stays 0
+```
+
+wine's `waveOutGetVolume()` does not fill the out parameter for the null handle
+MTGO passes, and the return code is discarded, so the method returns 0 and every
+single sound is dropped before it reaches a queue.  Measured directly on the
+unpatched client: `GetWindowsVolume() = 0`.
+
+**This is the one that matters most.**  Without it, nothing else is observable.
+
+### 2. Every sample goes through Media Foundation, which wine does not have
+
+`SoundQueue.ActiveSample..ctor`:
+
+```
+  IL_0034: ldarg.1
+  IL_0035: ldfld           field format      // sample.format
+  IL_003a: ldarg.3                           // the mixer's format
+  IL_003b: beq.s           -> IL_0055        // reference comparison!
+  IL_003d: ldarg.0
+  IL_003e: ldarg.0
+  IL_003f: ldfld           field stream
+  IL_0044: ldarg.3
+  IL_0045: newobj          NAudio.Wave.MediaFoundationResampler::.ctor
+```
+
+`beq` on two `WaveFormat` *references* is never true, so every sample is routed
+through `MediaFoundationResampler`, whose MFT is not registered in wine:
+
+```
+COMException: Retrieving the COM class factory for component with CLSID
+{F447B69E-1884-4A7E-8055-346F74D6EDB3} failed ... 0x80040154 (REGDB_E_CLASSNOTREG)
+```
+
+Worse, `AudioManager.PlaySoundSafe()` catches that exception and sets
+`m_mediaPlayerNotAvailable = true`, which disables audio for the rest of the
+session, so a single failure is terminal.
+
+### 3. `IsMuted()` casts wine COM objects to `ISimpleAudioVolume`
+
+`IsMuted()` enumerates WASAPI sessions (`IMMDeviceEnumerator`,
+`IAudioSessionManager2`, `IAudioSessionControl2`) and casts the current
+process's session to `ISimpleAudioVolume`.  On wine 9.8 the enumeration bails
+out early and the method harmlessly returns `false`; on wine 11 it reaches the
+cast, gets `E_NOINTERFACE` and throws `InvalidCastException` (this is what
+issue #217 reports).  It is patched defensively.
+
+### 4. Consequence: the mixer format must match the sound files
+
+Once the resampler is bypassed, a sample can only be added to the mixer if it
+already has the mixer's sample rate and channel count.  MTGO builds the mixer as
+**mono** 44100:
+
+```
+  IL_0052: ldc.i4          44100
+  IL_0057: ldc.i4.1                                             // channels
+  IL_0058: call            NAudio.Wave.WaveFormat::CreateIeeeFloatWaveFormat
+```
+
+while 96 of its 98 wav files are stereo 44100.  So the mixer is switched to
+stereo, and the two odd files (`Audio/Duel/WIN.wav`, `Audio/Duel/LOSE.wav`, mono
+22050) are converted on disk.
+
+## What the patch changes
+
+All of it is applied to the *installed* client inside your docker volume. No
+patched binary is distributed, and nothing is modified in the image.
+
+| Method | Change | Reason |
+| --- | --- | --- |
+| `Shiny.Utilities.AudioManager.IsMuted()` | body replaced by `ldc.i4.0; ret` | avoids the `ISimpleAudioVolume` cast |
+| `Shiny.Utilities.AudioManager.GetWindowsVolume()` | body replaced by `ldc.r8 1.0; ret` | wine reports 0, which mutes everything |
+| `SoundQueue..ctor` | `ldc.i4.1` → `ldc.i4.2` before `CreateIeeeFloatWaveFormat` | stereo mixer, matching the sound files |
+| `SoundQueue.ActiveSample..ctor` | the 4 comparison instructions → `br.s` to the "formats match" arm | never build a `MediaFoundationResampler` |
+| `Audio/**/*.wav` not in mixer format | converted to 2ch/44100/16 bit | required by the bypass above |
+| `AudioManager.GetVolume(...)` | `ldc.r8 1.0; ret`, **only with `--force-volume`** | MTGO's own sliders keep working by default |
+
+Original files are kept in the volume, outside the ClickOnce directory:
+
+```
+<volume>/wine/AppData/Local/mtgo-audio-patch/<app dir name>/
+    SharedResources.dll.orig
+    state.json          patched/original sha256, sample rate, converted wavs
+    wav/Audio/Duel/WIN.wav ...
+```
+
+`mtgo-audio-patch --restore` puts everything back.
+
+## Rules for IL patching here
+
+Learned by breaking them; the JIT check in `sound/tests/` catches each one.
+
+* **A method body cannot be resized.**  Its length is in the method header and
+  bodies are packed back to back.  Patches pad with `nop` (0x00) instead.
+* **A body must not fall off its end.**  Padding a replaced body with trailing
+  `nop`s produces `InvalidProgramException`, because execution runs past the last
+  byte.  `Body.replace_all()` therefore writes the padding *first* and lets the
+  new code end exactly on the last byte with its `ret`.
+* **The evaluation stack must be empty where control flow is rewritten.**  The
+  resampler bypass replaces the whole `ldarg/ldfld/ldarg/beq` group, not just the
+  branch, and refuses to patch unless the preceding instruction is a store or a
+  `pop`.
+* **Do not rewrite exception handling sections.**  When a body with handlers is
+  replaced wholesale, clearing `CorILMethod_MoreSects` (0x08) in the fat header
+  makes the CLR ignore the clauses; the bytes stay where they are.
+* **Match the return type before returning a constant.**  `ldc.r8` for
+  `float64`, `ldc.r4` for `float32`; the patcher reads the method signature.
+* **The only real verifier is the JIT.**  IL that disassembles perfectly can
+  still be rejected.  Always run `sound/tests/verify-audio.sh`.
+
+## The patcher
+
+`extra/mtgo-audio-patch.py`, standard library only (python3 is present in the
+base image, and `sound/Dockerfile` installs `python3-minimal` explicitly).
+
+Structure:
+
+| Part | What it does |
+| --- | --- |
+| `Assembly` | PE headers → CLI header → `#~` metadata; sizes tables 0x00-0x0A and reads `TypeDef`, `MethodDef`, `MemberRef`, the `#Strings`/`#Blob` heaps |
+| `disasm()` / `Insn` | full single-byte and `0xFE`-prefixed CIL decoder |
+| `Body` | method header (tiny/fat), code window, `write()`, `replace_all()`, `drop_exception_handlers()` |
+| `patch_*()` | one function per patch, each locating its target by pattern and raising `PatchError` rather than guessing |
+| `convert_wav()` | 16 bit PCM resample/upmix with `wave` + `array` |
+| `patch_app_dir()` | backups, state file, idempotency, restore |
+
+Everything is keyed on **names and code patterns**, never on file offsets:
+`find_methods('SoundQueue', '.ctor')` walks the metadata, and the mixer patch
+looks for "push a sample rate, push 1, call something" rather than a fixed
+address.  If a pattern is absent or ambiguous the patcher aborts that
+installation with a message and leaves the client untouched.
+
+Command line:
+
+```
+mtgo-audio-patch                     # patch every installation under $WINEPREFIX
+mtgo-audio-patch --app-dir DIR       # just this one
+mtgo-audio-patch --dry-run           # say what would happen
+mtgo-audio-patch --restore           # undo
+mtgo-audio-patch --force-volume      # also force GetVolume() to 1.0
+mtgo-audio-patch --no-wav            # do not convert sound files
+mtgo-audio-patch --dump [Type::Method ...]   # disassemble (see below)
+mtgo-audio-patch --dump --dll ./SharedResources.dll Type::Method
+```
+
+Integration points:
+
+| File | Role |
+| --- | --- |
+| `Dockerfile` | installs the script as `/usr/local/bin/mtgo-audio-patch` |
+| `sound/Dockerfile` | gstreamer, pulse client config, `python3-minimal`; `BASE` build arg |
+| `sound/local.Dockerfile` | sound image + patch on top of an existing base (`make sound-local`) |
+| `extra/mtgo.sh` | `--sound` runs the patch before launching, and again in the 6 s watchdog loop so a self-updated client is patched for the next start |
+| `run-mtgo` | `--sound`, `--no-audio-patch`, `--force-volume`; mounts the pulse socket |
+
+## Verifying
+
+```
+sound/tests/verify-audio.sh [IMAGE] [DOCKER_VOLUME]
+```
+
+Requires `docker`, `pactl`, `parec`, `python3` on the host.  It never touches
+the real installation: it copies the newest MTGO application directory out of
+the (read-only mounted) volume, restores the pristine DLL from the backup if
+there is one, and works on that copy.  Steps:
+
+1. compiles `sound/tests/JitCheck.cs` and `sound/tests/PlayTest.cs` with the
+   `csc.exe` of the wine prefix (.NET Framework 4.8 is installed in the image);
+2. **`JitCheck`** loads the assembly and calls `RuntimeHelpers.PrepareMethod()`
+   on every method of `AudioManager`, `SoundQueue` and `ActiveSample`, which
+   forces the JIT to import the IL, so invalid IL surfaces here as
+   `InvalidProgramException`, then calls `IsMuted()` and `GetWindowsVolume()`;
+3. applies the patch and repeats (2);
+4. **`PlayTest`** rebuilds MTGO's pipeline with MTGO's own NAudio and plays real
+   MTGO wav files into a throw-away null sink, which is recorded and measured;
+5. replays the same thing the way MTGO ships it (mono mixer +
+   `MediaFoundationResampler`), which must fail.
+
+Expected tail:
+
+```
+=== unpatched client (baseline: valid IL, and audio effectively muted)
+JIT: 44 ok, 0 failed
+IsMuted() = False
+GetWindowsVolume() = 0
+=== patched client (must JIT and report a usable volume)
+JIT: 44 ok, 0 failed
+GetWindowsVolume() = 1
+captured 4.8 s, peak=30999 rms=5045.9
+=== control: the pipeline as MTGO ships it (must fail under wine)
+FAILED GAME_BEGIN.wav -> COMException: ... REGDB_E_CLASSNOTREG
+ALL CHECKS PASSED
+```
+
+With MTGO actually running, the host side should show four uncorked streams:
+
+```
+pactl list sink-inputs | grep -B22 'Magic Online' \
+    | grep -E 'Sample Specification|Corked|Mute'
+        Sample Specification: float32le 2ch 44100Hz
+        Corked: no
+        Mute: no
+```
+
+`1ch` there means the mixer patch did not take effect.  To measure one of those
+streams: `parec --monitor-stream=<index> --format=s16le --rate=44100 --channels=2`.
+
+## When a client update breaks the patch
+
+`run-mtgo --sound` prints
+
+```
+mtgo-audio-patch: <app dir>: <what could not be found>
+mtgo-audio-patch: this MTGO version is not supported by the audio patch; sound may not work.
+```
+
+and starts MTGO unpatched.  To fix it:
+
+1. get the new DLL out of the volume:
+
+   ```
+   docker run --rm -v mtgo64-data-$USER:/data -v "$PWD":/out alpine sh -c \
+     'cp "$(ls -t $(find /data -name SharedResources.dll) | head -1)" /out/'
+   ```
+
+2. disassemble the methods involved and compare with the excerpts above:
+
+   ```
+   python3 extra/mtgo-audio-patch.py --dump --dll ./SharedResources.dll
+   python3 extra/mtgo-audio-patch.py --dump --dll ./SharedResources.dll 'SoundQueue::.ctor'
+   ```
+
+   `--dump` resolves call targets and field names, so the code reads like the
+   listings in this document.  Method names are `[Namespace.]Type::Method`;
+   nested types are addressed by their own name (`ActiveSample::.ctor`).
+
+3. adapt the matcher in the relevant `patch_*()` function.  Keep the pattern
+   descriptive (opcode sequence, resolved call target) rather than positional,
+   and keep it failing loudly when it does not match.
+
+4. re-read [Rules for IL patching here](#rules-for-il-patching-here), then run
+   `sound/tests/verify-audio.sh`.  A patch is not done until `JIT: … 0 failed`
+   and a non-zero capture.
+
+5. if MTGO changed something structural (a new audio backend, WASAPI instead of
+   winmm, encoded assets instead of wav), re-check whether the patch is still
+   needed at all: run the control step first, since wine may also have gained
+   the missing pieces in the meantime.
+
+## Known limitations
+
+* A client update that lands while MTGO is running is patched by the watchdog
+  loop, but the running process keeps the code it loaded: sound comes back at
+  the next start.
+* The resampler bypass assumes every sound file matches the mixer format; the
+  patcher converts the ones that do not, and would need extending if MTGO ever
+  ships something other than PCM wav.
+* `--force-volume` disables MTGO's own volume sliders; it exists only as a
+  fallback if the settings path also misbehaves.
+* Only tested on Linux with PulseAudio/PipeWire.  The macOS path in `run-mtgo`
+  (TCP PulseAudio) is untested for the patch.
+* `mtgo-audio-patch` rewrites managed code of a client you are licensed to run,
+  locally; do not redistribute patched DLLs.

--- a/extra/mtgo-audio-patch.py
+++ b/extra/mtgo-audio-patch.py
@@ -1,0 +1,1018 @@
+#!/usr/bin/env python3
+"""Patch the locally installed MTGO client so that its audio works under Wine.
+
+MTGO's managed audio code takes three paths that Wine cannot serve:
+
+  * ``AudioManager.IsMuted()`` enumerates WASAPI sessions and casts them to
+    ``ISimpleAudioVolume``.  Wine answers ``E_NOINTERFACE`` and the client dies
+    with an ``InvalidCastException``.
+  * ``AudioManager.GetWindowsVolume()`` reads the master volume through
+    ``waveOutGetVolume(IntPtr.Zero, ...)``.  Wine leaves the value at 0, so every
+    sound is played at volume 0.
+  * every sample is pushed through ``MediaFoundationResampler`` because the
+    format comparison in ``SoundQueue.ActiveSample..ctor`` compares
+    ``WaveFormat`` *references*, which never match.  Media Foundation is not
+    usable in Wine, so playback crashes or stays silent.
+
+This script rewrites those code paths in the ``SharedResources.dll`` of your own
+installation (no patched binary is distributed), and converts the handful of
+sound files whose format does not match the mixer, since bypassing the resampler
+requires the samples to already be in the mixer's format.
+
+Everything is reversible: originals are kept outside the ClickOnce application
+directory and ``--restore`` puts them back.
+
+Nothing but the Python standard library is required.
+
+See https://github.com/pauleve/docker-mtgo/issues/217
+"""
+
+import argparse
+import array
+import hashlib
+import json
+import os
+import shutil
+import struct
+import sys
+import time
+import wave
+
+VERSION = 2
+
+# --------------------------------------------------------------------------
+# CIL opcodes: mnemonic + operand kind, enough to walk a method body
+# --------------------------------------------------------------------------
+
+NONE, U1, I1, I2, U2, I4, I8, R4, R8, TOK, BR1, BR4, SWITCH = range(13)
+OPSZ = {NONE: 0, U1: 1, I1: 1, I2: 2, U2: 2, I4: 4, I8: 8, R4: 4, R8: 8,
+        TOK: 4, BR1: 1, BR4: 4}
+
+OPS1 = {
+    0x00: ('nop', NONE), 0x01: ('break', NONE),
+    0x02: ('ldarg.0', NONE), 0x03: ('ldarg.1', NONE), 0x04: ('ldarg.2', NONE),
+    0x05: ('ldarg.3', NONE),
+    0x06: ('ldloc.0', NONE), 0x07: ('ldloc.1', NONE), 0x08: ('ldloc.2', NONE),
+    0x09: ('ldloc.3', NONE),
+    0x0a: ('stloc.0', NONE), 0x0b: ('stloc.1', NONE), 0x0c: ('stloc.2', NONE),
+    0x0d: ('stloc.3', NONE),
+    0x0e: ('ldarg.s', U1), 0x0f: ('ldarga.s', U1), 0x10: ('starg.s', U1),
+    0x11: ('ldloc.s', U1), 0x12: ('ldloca.s', U1), 0x13: ('stloc.s', U1),
+    0x14: ('ldnull', NONE), 0x15: ('ldc.i4.m1', NONE),
+    0x16: ('ldc.i4.0', NONE), 0x17: ('ldc.i4.1', NONE), 0x18: ('ldc.i4.2', NONE),
+    0x19: ('ldc.i4.3', NONE), 0x1a: ('ldc.i4.4', NONE), 0x1b: ('ldc.i4.5', NONE),
+    0x1c: ('ldc.i4.6', NONE), 0x1d: ('ldc.i4.7', NONE), 0x1e: ('ldc.i4.8', NONE),
+    0x1f: ('ldc.i4.s', I1), 0x20: ('ldc.i4', I4), 0x21: ('ldc.i8', I8),
+    0x22: ('ldc.r4', R4), 0x23: ('ldc.r8', R8),
+    0x25: ('dup', NONE), 0x26: ('pop', NONE), 0x27: ('jmp', TOK),
+    0x28: ('call', TOK), 0x29: ('calli', TOK), 0x2a: ('ret', NONE),
+    0x2b: ('br.s', BR1), 0x2c: ('brfalse.s', BR1), 0x2d: ('brtrue.s', BR1),
+    0x2e: ('beq.s', BR1), 0x2f: ('bge.s', BR1), 0x30: ('bgt.s', BR1),
+    0x31: ('ble.s', BR1), 0x32: ('blt.s', BR1), 0x33: ('bne.un.s', BR1),
+    0x34: ('bge.un.s', BR1), 0x35: ('bgt.un.s', BR1), 0x36: ('ble.un.s', BR1),
+    0x37: ('blt.un.s', BR1),
+    0x38: ('br', BR4), 0x39: ('brfalse', BR4), 0x3a: ('brtrue', BR4),
+    0x3b: ('beq', BR4), 0x3c: ('bge', BR4), 0x3d: ('bgt', BR4),
+    0x3e: ('ble', BR4), 0x3f: ('blt', BR4), 0x40: ('bne.un', BR4),
+    0x41: ('bge.un', BR4), 0x42: ('bgt.un', BR4), 0x43: ('ble.un', BR4),
+    0x44: ('blt.un', BR4), 0x45: ('switch', SWITCH),
+    0x6f: ('callvirt', TOK), 0x70: ('cpobj', TOK), 0x71: ('ldobj', TOK),
+    0x72: ('ldstr', TOK), 0x73: ('newobj', TOK), 0x74: ('castclass', TOK),
+    0x75: ('isinst', TOK), 0x79: ('unbox', TOK), 0x7a: ('throw', NONE),
+    0x7b: ('ldfld', TOK), 0x7c: ('ldflda', TOK), 0x7d: ('stfld', TOK),
+    0x7e: ('ldsfld', TOK), 0x7f: ('ldsflda', TOK), 0x80: ('stsfld', TOK),
+    0x81: ('stobj', TOK), 0x8c: ('box', TOK), 0x8d: ('newarr', TOK),
+    0x8f: ('ldelema', TOK), 0xa3: ('ldelem', TOK), 0xa4: ('stelem', TOK),
+    0xa5: ('unbox.any', TOK), 0xc2: ('refanyval', TOK), 0xc6: ('mkrefany', TOK),
+    0xd0: ('ldtoken', TOK),
+    0xdc: ('endfinally', NONE), 0xdd: ('leave', BR4), 0xde: ('leave.s', BR1),
+}
+# the remaining single-byte opcodes take no operand
+for _base, _names in (
+    (0x46, 'ldind.i1 ldind.u1 ldind.i2 ldind.u2 ldind.i4 ldind.u4 ldind.i8 ldind.i '
+           'ldind.r4 ldind.r8 ldind.ref stind.ref stind.i1 stind.i2 stind.i4 stind.i8 '
+           'stind.r4 stind.r8 add sub mul div div.un rem rem.un and or xor shl shr '
+           'shr.un neg not conv.i1 conv.i2 conv.i4 conv.i8 conv.r4 conv.r8 conv.u4 '
+           'conv.u8'),
+    (0x76, 'conv.r.un'),
+    (0x82, 'conv.ovf.i1.un conv.ovf.i2.un conv.ovf.i4.un conv.ovf.i8.un conv.ovf.u1.un '
+           'conv.ovf.u2.un conv.ovf.u4.un conv.ovf.u8.un conv.ovf.i.un conv.ovf.u.un'),
+    (0x8e, 'ldlen'),
+    (0x90, 'ldelem.i1 ldelem.u1 ldelem.i2 ldelem.u2 ldelem.i4 ldelem.u4 ldelem.i8 '
+           'ldelem.i ldelem.r4 ldelem.r8 ldelem.ref stelem.i stelem.i1 stelem.i2 '
+           'stelem.i4 stelem.i8 stelem.r4 stelem.r8 stelem.ref'),
+    (0xb3, 'conv.ovf.i1 conv.ovf.u1 conv.ovf.i2 conv.ovf.u2 conv.ovf.i4 conv.ovf.u4 '
+           'conv.ovf.i8 conv.ovf.u8'),
+    (0xc3, 'ckfinite'),
+    (0xd1, 'conv.u2 conv.u1 conv.i conv.ovf.i conv.ovf.u add.ovf add.ovf.un mul.ovf '
+           'mul.ovf.un sub.ovf sub.ovf.un'),
+    (0xdf, 'stind.i conv.u'),
+):
+    for _i, _name in enumerate(_names.split()):
+        OPS1.setdefault(_base + _i, (_name, NONE))
+for _op in range(0x00, 0xe1):
+    OPS1.setdefault(_op, ('op.%02x' % _op, NONE))
+
+OPS2 = {
+    0x00: ('arglist', NONE), 0x01: ('ceq', NONE), 0x02: ('cgt', NONE),
+    0x03: ('cgt.un', NONE), 0x04: ('clt', NONE), 0x05: ('clt.un', NONE),
+    0x06: ('ldftn', TOK), 0x07: ('ldvirtftn', TOK), 0x09: ('ldarg', U2),
+    0x0a: ('ldarga', U2), 0x0b: ('starg', U2), 0x0c: ('ldloc', U2),
+    0x0d: ('ldloca', U2), 0x0e: ('stloc', U2), 0x0f: ('localloc', NONE),
+    0x11: ('endfilter', NONE), 0x12: ('unaligned.', U1), 0x13: ('volatile.', NONE),
+    0x14: ('tail.', NONE), 0x15: ('initobj', TOK), 0x16: ('constrained.', TOK),
+    0x17: ('cpblk', NONE), 0x18: ('initblk', NONE), 0x19: ('no.', U1),
+    0x1a: ('rethrow', NONE), 0x1c: ('sizeof', TOK), 0x1d: ('refanytype', NONE),
+    0x1e: ('readonly.', NONE),
+}
+
+
+class Insn(object):
+    __slots__ = ('off', 'size', 'name', 'kind', 'value')
+
+    def __init__(self, off, size, name, kind, value):
+        self.off, self.size, self.name, self.kind, self.value = \
+            off, size, name, kind, value
+
+    @property
+    def end(self):
+        return self.off + self.size
+
+    def __repr__(self):
+        return 'IL_%04x: %s%s' % (self.off, self.name,
+                                  '' if self.value is None else ' %s' % (self.value,))
+
+
+def disasm(code):
+    """Decode a method body into a list of Insn (offsets relative to the code)."""
+    out = []
+    i = 0
+    n = len(code)
+    while i < n:
+        start = i
+        if code[i] == 0xfe:
+            name, kind = OPS2.get(code[i + 1], ('unk.fe%02x' % code[i + 1], NONE))
+            i += 2
+        else:
+            name, kind = OPS1[code[i]]
+            i += 1
+        value = None
+        if kind == SWITCH:
+            cnt = struct.unpack_from('<I', code, i)[0]
+            i += 4 + 4 * cnt
+        else:
+            sz = OPSZ[kind]
+            if sz:
+                if kind == I1:
+                    value = struct.unpack_from('<b', code, i)[0]
+                elif kind == U1:
+                    value = code[i]
+                elif kind == I2:
+                    value = struct.unpack_from('<h', code, i)[0]
+                elif kind == U2:
+                    value = struct.unpack_from('<H', code, i)[0]
+                elif kind == I4:
+                    value = struct.unpack_from('<i', code, i)[0]
+                elif kind == I8:
+                    value = struct.unpack_from('<q', code, i)[0]
+                elif kind == R4:
+                    value = struct.unpack_from('<f', code, i)[0]
+                elif kind == R8:
+                    value = struct.unpack_from('<d', code, i)[0]
+                elif kind == TOK:
+                    value = struct.unpack_from('<I', code, i)[0]
+                elif kind == BR1:
+                    value = i + 1 + struct.unpack_from('<b', code, i)[0]
+                elif kind == BR4:
+                    value = i + 4 + struct.unpack_from('<i', code, i)[0]
+                i += sz
+        out.append(Insn(start, i - start, name, kind, value))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Just enough ECMA-335 metadata to find a method body in the file
+# --------------------------------------------------------------------------
+
+# tables we walk over, in table order; rows are laid out in table order, so
+# reaching MemberRef (0x0A) means sizing everything below it as well.
+NTABLES = 0x0B
+
+
+class Assembly(object):
+    def __init__(self, data):
+        self.data = bytearray(data)
+        self._parse_pe()
+        self._parse_metadata()
+
+    # -- PE ----------------------------------------------------------------
+    def _parse_pe(self):
+        d = self.data
+        if d[:2] != b'MZ':
+            raise ValueError('not a PE file')
+        pe = struct.unpack_from('<I', d, 0x3c)[0]
+        if d[pe:pe + 4] != b'PE\0\0':
+            raise ValueError('not a PE file')
+        coff = pe + 4
+        nsec, = struct.unpack_from('<H', d, coff + 2)
+        opt_size, = struct.unpack_from('<H', d, coff + 16)
+        opt = coff + 20
+        magic, = struct.unpack_from('<H', d, opt)
+        dirs = opt + (96 if magic == 0x10b else 112)
+        sect = opt + opt_size
+        self.sections = []
+        for i in range(nsec):
+            s = sect + 40 * i
+            vsize, vaddr, rsize, raddr = struct.unpack_from('<IIII', d, s + 8)
+            self.sections.append((vaddr, max(vsize, rsize), raddr))
+        cli_rva, = struct.unpack_from('<I', d, dirs + 14 * 8)
+        if not cli_rva:
+            raise ValueError('not a managed assembly')
+        cli = self.rva2off(cli_rva)
+        md_rva, = struct.unpack_from('<I', d, cli + 8)
+        self.md = self.rva2off(md_rva)
+
+    def rva2off(self, rva):
+        for vaddr, vsize, raddr in self.sections:
+            if vaddr <= rva < vaddr + vsize:
+                return rva - vaddr + raddr
+        raise ValueError('RVA %#x outside of any section' % rva)
+
+    # -- metadata ----------------------------------------------------------
+    def _parse_metadata(self):
+        d = self.data
+        md = self.md
+        if struct.unpack_from('<I', d, md)[0] != 0x424A5342:
+            raise ValueError('bad metadata signature')
+        vlen, = struct.unpack_from('<I', d, md + 12)
+        p = md + 16 + ((vlen + 3) & ~3)
+        nstreams, = struct.unpack_from('<H', d, p + 2)
+        p += 4
+        streams = {}
+        for _ in range(nstreams):
+            off, size = struct.unpack_from('<II', d, p)
+            p += 8
+            end = d.index(b'\0', p)
+            name = bytes(d[p:end]).decode('ascii')
+            p = md + (((end + 1 - md) + 3) & ~3)
+            streams[name] = (md + off, size)
+        self.streams = streams
+        if '#~' not in streams:
+            raise ValueError('unsupported (uncompressed) metadata stream')
+        self.strings = streams['#Strings'][0]
+        self.blobs = streams.get('#Blob', (0, 0))[0]
+        self._parse_tables(*streams['#~'])
+
+    def _parse_tables(self, off, size):
+        d = self.data
+        heaps = d[off + 6]
+        valid, = struct.unpack_from('<Q', d, off + 8)
+        p = off + 24
+        rows = {}
+        for t in range(64):
+            if valid & (1 << t):
+                rows[t] = struct.unpack_from('<I', d, p)[0]
+                p += 4
+        self.rows = rows
+        self.str_sz = 4 if heaps & 0x01 else 2
+        self.guid_sz = 4 if heaps & 0x02 else 2
+        self.blob_sz = 4 if heaps & 0x04 else 2
+
+        def idx(*tables):
+            return 4 if max(rows.get(t, 0) for t in tables) >= 0x10000 else 2
+
+        def coded(bits, *tables):
+            limit = 1 << (16 - bits)
+            return 4 if max(rows.get(t, 0) for t in tables) >= limit else 2
+
+        S, G, B = self.str_sz, self.guid_sz, self.blob_sz
+        res_scope = coded(2, 0x00, 0x1A, 0x23, 0x01)
+        typedeforref = coded(2, 0x02, 0x01, 0x1B)
+        self.memberref_parent = coded(3, 0x02, 0x01, 0x1A, 0x06, 0x1B)
+        self.field_idx = idx(0x04)
+        self.method_idx = idx(0x06)
+        self.param_idx = idx(0x08)
+        sizes = {
+            0x00: 2 + S + 3 * G,
+            0x01: res_scope + 2 * S,
+            0x02: 4 + 2 * S + typedeforref + self.field_idx + self.method_idx,
+            0x03: self.field_idx,
+            0x04: 2 + S + B,
+            0x05: self.method_idx,
+            0x06: 4 + 2 + 2 + S + B + self.param_idx,
+            0x07: self.param_idx,
+            0x08: 2 + 2 + S,
+            0x09: idx(0x02) + typedeforref,
+            0x0a: self.memberref_parent + S + B,
+        }
+        self.row_size = sizes
+        self.table_off = {}
+        q = p
+        for t in range(NTABLES):
+            if t in rows:
+                self.table_off[t] = q
+                q += rows[t] * sizes[t]
+
+    # -- accessors ---------------------------------------------------------
+    def _uint(self, off, size):
+        if size == 2:
+            return struct.unpack_from('<H', self.data, off)[0]
+        return struct.unpack_from('<I', self.data, off)[0]
+
+    def string(self, idx):
+        d = self.data
+        start = self.strings + idx
+        return bytes(d[start:d.index(b'\0', start)]).decode('utf-8', 'replace')
+
+    def blob(self, idx):
+        d = self.data
+        p = self.blobs + idx
+        b0 = d[p]
+        if b0 & 0x80 == 0:
+            n, p = b0, p + 1
+        elif b0 & 0xC0 == 0x80:
+            n, p = ((b0 & 0x3F) << 8) | d[p + 1], p + 2
+        else:
+            n = ((b0 & 0x1F) << 24) | (d[p + 1] << 16) | (d[p + 2] << 8) | d[p + 3]
+            p += 4
+        return bytes(d[p:p + n])
+
+    def typedefs(self):
+        """Yield (namespace, name, first_method_rid) for every TypeDef."""
+        n = self.rows.get(0x02, 0)
+        base = self.table_off[0x02]
+        sz = self.row_size[0x02]
+        S = self.str_sz
+        for i in range(n):
+            r = base + i * sz
+            name = self.string(self._uint(r + 4, S))
+            ns = self.string(self._uint(r + 4 + S, S))
+            mlist = self._uint(r + sz - self.method_idx, self.method_idx)
+            yield ns, name, mlist
+
+    def methods_of(self, rid_start, rid_end):
+        """Yield (name, rva, signature_blob) for MethodDef rids in [start, end)."""
+        base = self.table_off[0x06]
+        sz = self.row_size[0x06]
+        S, B = self.str_sz, self.blob_sz
+        n = self.rows.get(0x06, 0)
+        for rid in range(rid_start, min(rid_end, n + 1)):
+            r = base + (rid - 1) * sz
+            rva, = struct.unpack_from('<I', self.data, r)
+            name = self.string(self._uint(r + 8, S))
+            sig = self.blob(self._uint(r + 8 + S, B))
+            yield name, rva, sig
+
+    def _row(self, table, rid):
+        return self.table_off[table] + (rid - 1) * self.row_size[table]
+
+    def type_name(self, table, rid):
+        """Full name of a TypeDef (0x02) or TypeRef (0x01) row."""
+        S = self.str_sz
+        if table == 0x02:
+            r = self._row(0x02, rid)
+            name, ns = self.string(self._uint(r + 4, S)), self.string(self._uint(r + 4 + S, S))
+        elif table == 0x01:
+            r = self._row(0x01, rid)
+            base = self.row_size[0x01] - 2 * S
+            name, ns = self.string(self._uint(r + base, S)), \
+                self.string(self._uint(r + base + S, S))
+        else:
+            return 'table%02x[%d]' % (table, rid)
+        return '%s.%s' % (ns, name) if ns else name
+
+    MEMBERREF_PARENT = {0: 0x02, 1: 0x01, 2: 0x1A, 3: 0x06, 4: 0x1B}
+
+    def token_name(self, tok):
+        """Best-effort human readable name for a metadata token."""
+        table, rid = tok >> 24, tok & 0xFFFFFF
+        S = self.str_sz
+        try:
+            if table == 0x0A:  # MemberRef
+                r = self._row(0x0a, rid)
+                parent = self._uint(r, self.memberref_parent)
+                name = self.string(self._uint(r + self.memberref_parent, S))
+                ptable = self.MEMBERREF_PARENT.get(parent & 7)
+                owner = self.type_name(ptable, parent >> 3) if ptable in (0x01, 0x02) \
+                    else 'table%02x[%d]' % (ptable, parent >> 3)
+                return '%s::%s' % (owner, name)
+            if table == 0x06:  # MethodDef
+                return '%s (this assembly)' % self.string(
+                    self._uint(self._row(0x06, rid) + 8, S))
+            if table == 0x04:  # Field
+                return 'field %s' % self.string(self._uint(self._row(0x04, rid) + 2, S))
+            if table in (0x01, 0x02):
+                return self.type_name(table, rid)
+            if table == 0x70:
+                return '"..."'
+        except Exception:
+            pass
+        return 'token(%08x)' % tok
+
+    def find_methods(self, type_name, method_name, namespace=None):
+        """Return [(full_type_name, rva, signature)] matching a type/method name."""
+        tds = list(self.typedefs())
+        nmethods = self.rows.get(0x06, 0)
+        out = []
+        for i, (ns, name, mlist) in enumerate(tds):
+            if name != type_name:
+                continue
+            if namespace is not None and ns != namespace:
+                continue
+            end = tds[i + 1][2] if i + 1 < len(tds) else nmethods + 1
+            for mname, rva, sig in self.methods_of(mlist, end):
+                if mname == method_name and rva:
+                    out.append(('%s.%s' % (ns, name) if ns else name, rva, sig))
+        return out
+
+
+def sig_return_type(sig):
+    """Return the ELEMENT_TYPE byte of a method signature's return type."""
+    p = 0
+    conv = sig[p]
+    p += 1
+    if conv & 0x10:  # generic
+        p += _skip_compressed(sig, p)
+    p += _skip_compressed(sig, p)  # param count
+    while sig[p] in (0x1f, 0x20):  # CMOD_REQD / CMOD_OPT
+        p += 1
+        p += _skip_compressed(sig, p)
+    return sig[p]
+
+
+def _skip_compressed(b, p):
+    if b[p] & 0x80 == 0:
+        return 1
+    if b[p] & 0xC0 == 0x80:
+        return 2
+    return 4
+
+
+class Body(object):
+    """A method body: header, code and the ability to rewrite both."""
+
+    def __init__(self, asm, rva):
+        self.asm = asm
+        self.off = asm.rva2off(rva)
+        d = asm.data
+        b0 = d[self.off]
+        if (b0 & 0x3) == 0x2:
+            self.fat = False
+            self.hdr = 1
+            self.size = b0 >> 2
+        else:
+            self.fat = True
+            flags, = struct.unpack_from('<H', d, self.off)
+            self.hdr = (flags >> 12) * 4
+            self.flags = flags
+            self.size, = struct.unpack_from('<I', d, self.off + 4)
+        self.code_off = self.off + self.hdr
+
+    @property
+    def code(self):
+        return self.asm.data[self.code_off:self.code_off + self.size]
+
+    def disasm(self):
+        return disasm(self.code)
+
+    def write(self, rel_off, data):
+        if rel_off + len(data) > self.size:
+            raise ValueError('patch does not fit in method body')
+        self.asm.data[self.code_off + rel_off:self.code_off + rel_off + len(data)] = data
+
+    def drop_exception_handlers(self):
+        """Clear CorILMethod_MoreSects so the (now unused) EH clauses are ignored."""
+        if self.fat and (self.flags & 0x08):
+            self.flags &= ~0x08
+            struct.pack_into('<H', self.asm.data, self.off, self.flags)
+
+    def replace_all(self, code):
+        """Replace the whole body with `code`.
+
+        The padding goes *before* the new code: a method body may not fall off
+        its end, so the replacement has to finish exactly on the last byte with
+        its `ret`, and the leading nops simply run into it.
+        """
+        if len(code) > self.size:
+            raise ValueError('replacement body too large')
+        self.drop_exception_handlers()
+        self.write(0, b'\x00' * (self.size - len(code)) + code)
+
+
+# --------------------------------------------------------------------------
+# the patches
+# --------------------------------------------------------------------------
+
+ELEMENT_TYPE_BOOLEAN = 0x02
+ELEMENT_TYPE_R4 = 0x0C
+ELEMENT_TYPE_R8 = 0x0D
+
+LDC_I4_0, LDC_I4_1, LDC_I4_2, LDC_R4, LDC_R8, RET, BR_S, BR, NOP = \
+    b'\x16', b'\x17', b'\x18', b'\x22', b'\x23', b'\x2a', b'\x2b', b'\x38', b'\x00'
+
+
+class PatchError(Exception):
+    pass
+
+
+def _single(asm, type_name, method_name, namespace=None):
+    found = asm.find_methods(type_name, method_name, namespace)
+    if not found:
+        raise PatchError('%s.%s not found' % (type_name, method_name))
+    if len(found) > 1:
+        raise PatchError('%s.%s is ambiguous (%d matches)'
+                         % (type_name, method_name, len(found)))
+    return found[0]
+
+
+def patch_is_muted(asm):
+    """AudioManager.IsMuted() -> false, without touching WASAPI/COM."""
+    name, rva, sig = _single(asm, 'AudioManager', 'IsMuted', 'Shiny.Utilities')
+    if sig_return_type(sig) != ELEMENT_TYPE_BOOLEAN:
+        raise PatchError('%s.IsMuted does not return bool' % name)
+    body = Body(asm, rva)
+    ops = body.disasm()
+    if not any(op.name in ('callvirt', 'call') for op in ops):
+        raise PatchError('IsMuted looks already patched or unexpected')
+    body.replace_all(LDC_I4_0 + RET)
+    return 'IsMuted() -> false (was %d bytes of WASAPI session enumeration)' % body.size
+
+
+def _return_one(asm, type_name, method_name, namespace=None):
+    name, rva, sig = _single(asm, type_name, method_name, namespace)
+    ret = sig_return_type(sig)
+    if ret == ELEMENT_TYPE_R8:
+        code = LDC_R8 + struct.pack('<d', 1.0) + RET
+    elif ret == ELEMENT_TYPE_R4:
+        code = LDC_R4 + struct.pack('<f', 1.0) + RET
+    else:
+        raise PatchError('%s.%s does not return a float' % (name, method_name))
+    body = Body(asm, rva)
+    body.replace_all(code)
+    return '%s() -> 1.0' % method_name
+
+
+def patch_windows_volume(asm):
+    """AudioManager.GetWindowsVolume() -> 1.0.
+
+    Wine's waveOutGetVolume() leaves the out parameter at 0 for the null
+    handle MTGO passes, which mutes every sample.
+    """
+    return _return_one(asm, 'AudioManager', 'GetWindowsVolume', 'Shiny.Utilities')
+
+
+def patch_get_volume(asm):
+    """AudioManager.GetVolume(setting) -> 1.0 (optional: ignores in-game sliders)."""
+    return _return_one(asm, 'AudioManager', 'GetVolume', 'Shiny.Utilities')
+
+
+def patch_mixer_stereo(asm):
+    """SoundQueue..ctor: build the mixer in stereo instead of mono.
+
+    Returns (message, sample_rate) -- the sample rate every sound file must use
+    once the resampler is bypassed.
+    """
+    name, rva, sig = _single(asm, 'SoundQueue', '.ctor')
+    body = Body(asm, rva)
+    ops = body.disasm()
+    hits = []
+    for i in range(len(ops) - 2):
+        rate = ops[i]
+        chan = ops[i + 1]
+        call = ops[i + 2]
+        if rate.name not in ('ldc.i4', 'ldc.i4.s'):
+            continue
+        if not (8000 <= (rate.value or 0) <= 192000):
+            continue
+        if call.name != 'call':
+            continue
+        if chan.name == 'ldc.i4.2':
+            return ('mixer already stereo @ %dHz' % rate.value, rate.value)
+        if chan.name != 'ldc.i4.1':
+            continue
+        hits.append((i, rate.value))
+    if len(hits) != 1:
+        raise PatchError('expected exactly one mono mixer format in SoundQueue..ctor,'
+                         ' found %d' % len(hits))
+    i, rate = hits[0]
+    body.write(ops[i + 1].off, LDC_I4_2)
+    return ('mixer format 1ch -> 2ch @ %dHz' % rate, rate)
+
+
+def patch_bypass_resampler(asm):
+    """SoundQueue.ActiveSample..ctor: never build a MediaFoundationResampler.
+
+    The original code is
+
+        if (sample.format == outputFormat) source = stream;
+        else source = new MediaFoundationResampler(stream, outputFormat);
+
+    where the comparison is a reference comparison that is never true.  Media
+    Foundation is not usable under Wine, so the branch is turned into an
+    unconditional jump to the "formats already match" arm.  The comparison
+    operands are removed as well, so the evaluation stack stays empty and the
+    result still verifies.
+    """
+    name, rva, sig = _single(asm, 'ActiveSample', '.ctor')
+    body = Body(asm, rva)
+    ops = body.disasm()
+    by_off = dict((op.off, i) for i, op in enumerate(ops))
+    hits = []
+    for i in range(3, len(ops)):
+        beq = ops[i]
+        if beq.name not in ('beq.s', 'beq'):
+            continue
+        a, fld, b = ops[i - 3], ops[i - 2], ops[i - 1]
+        if not (a.name.startswith('ldarg') and fld.name == 'ldfld'
+                and b.name.startswith('ldarg')):
+            continue
+        # the sequence must start on an empty evaluation stack
+        prev = ops[i - 4]
+        if not (prev.name.startswith('stfld') or prev.name.startswith('stloc')
+                or prev.name.startswith('stsfld') or prev.name == 'pop'):
+            continue
+        # the not-taken arm must be the one building the resampler
+        j = by_off.get(beq.end)
+        if j is None or not any(op.name == 'newobj'
+                                for op in ops[j:by_off.get(beq.value, j)]):
+            continue
+        hits.append(i)
+    if len(hits) != 1:
+        raise PatchError('expected exactly one resampler branch in ActiveSample..ctor,'
+                         ' found %d' % len(hits))
+    i = hits[0]
+    start = ops[i - 3].off
+    end = ops[i].end
+    target = ops[i].value
+    delta = target - (start + 2)
+    if -128 <= delta <= 127:
+        jump = BR_S + struct.pack('<b', delta)
+    else:
+        jump = BR + struct.pack('<i', target - (start + 5))
+    body.write(start, jump + NOP * (end - start - len(jump)))
+    return 'MediaFoundationResampler bypassed (IL_%04x -> IL_%04x)' % (start, target)
+
+
+DUMP_DEFAULT = [
+    'Shiny.Utilities.AudioManager::IsMuted',
+    'Shiny.Utilities.AudioManager::GetWindowsVolume',
+    'Shiny.Utilities.AudioManager::GetVolume',
+    'Shiny.Utilities.AudioManager::PlaySound',
+    'SoundQueue::.ctor',
+    'ActiveSample::.ctor',
+]
+
+
+def dump_methods(data, specs, out=sys.stdout):
+    """Disassemble methods given as [Namespace.]Type::Method.
+
+    This is what the patches were derived from: when a client update makes a
+    patch fail, dump the methods below and compare with what the patch expects.
+    """
+    asm = Assembly(data)
+    for spec in specs:
+        type_part, _, method = spec.partition('::')
+        namespace, _, type_name = type_part.rpartition('.')
+        found = asm.find_methods(type_name, method, namespace or None)
+        if not found:
+            out.write('\n=== %s: not found\n' % spec)
+            continue
+        for name, rva, sig in found:
+            body = Body(asm, rva)
+            out.write('\n=== %s::%s  rva=%#x  %s  code_size=%d  return_type=%#x%s\n'
+                      % (name, method, rva, 'fat' if body.fat else 'tiny', body.size,
+                         sig_return_type(sig),
+                         '  exception handlers' if body.fat and (body.flags & 8) else ''))
+            for op in disasm(body.code):
+                if op.kind == TOK:
+                    detail = '  ' + asm.token_name(op.value)
+                elif op.kind in (BR1, BR4):
+                    detail = '  -> IL_%04x' % op.value
+                elif op.value is not None:
+                    detail = '  %s' % (op.value,)
+                else:
+                    detail = ''
+                out.write('  IL_%04x: %s\n'
+                          % (op.off, ('%-14s%s' % (op.name, detail)).rstrip()))
+
+
+def already_patched(asm):
+    """True when IsMuted() is already the two-instruction stub."""
+    try:
+        name, rva, sig = _single(asm, 'AudioManager', 'IsMuted', 'Shiny.Utilities')
+    except PatchError:
+        return False
+    code = Body(asm, rva).code
+    return bytes(code[-2:]) == LDC_I4_0 + RET and set(code[:-2]) <= {0x00}
+
+
+def patch_assembly(data, force_volume=False):
+    """Apply every patch to `data`; return (new_bytes, messages, sample_rate)."""
+    asm = Assembly(data)
+    msgs = []
+    msgs.append(patch_is_muted(asm))
+    msgs.append(patch_windows_volume(asm))
+    if force_volume:
+        msgs.append(patch_get_volume(asm))
+    msg, rate = patch_mixer_stereo(asm)
+    msgs.append(msg)
+    msgs.append(patch_bypass_resampler(asm))
+    return bytes(asm.data), msgs, rate
+
+
+# --------------------------------------------------------------------------
+# sound files
+# --------------------------------------------------------------------------
+
+def convert_wav(src, dst, rate, channels=2):
+    """Rewrite a PCM wav as `channels` x `rate`, 16 bit.  Returns a description."""
+    with wave.open(src, 'rb') as w:
+        nch, width, sr, nframes = (w.getnchannels(), w.getsampwidth(),
+                                   w.getframerate(), w.getnframes())
+        if w.getcomptype() != 'NONE':
+            raise ValueError('compressed wav')
+        raw = w.readframes(nframes)
+    if width != 2 or nch not in (1, 2):
+        raise ValueError('unsupported %d-bit %dch wav' % (width * 8, nch))
+    samples = array.array('h')
+    samples.frombytes(raw)
+    if sys.byteorder == 'big':
+        samples.byteswap()
+    if nch == 2:
+        left = samples[0::2]
+        right = samples[1::2]
+    else:
+        left = right = samples
+    n = len(left)
+    if sr != rate and n:
+        step = float(sr) / rate
+        m = int(n / step)
+        out_l = array.array('h', bytes(2 * m))
+        out_r = array.array('h', bytes(2 * m))
+        for i in range(m):
+            pos = i * step
+            k = int(pos)
+            frac = pos - k
+            k2 = min(k + 1, n - 1)
+            out_l[i] = int(left[k] + (left[k2] - left[k]) * frac)
+            out_r[i] = int(right[k] + (right[k2] - right[k]) * frac)
+        left, right = out_l, out_r
+    inter = array.array('h', bytes(4 * len(left)))
+    inter[0::2] = left
+    inter[1::2] = right
+    if sys.byteorder == 'big':
+        inter.byteswap()
+    with wave.open(dst, 'wb') as w:
+        w.setnchannels(2)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(inter.tobytes())
+    return '%dch %dHz -> 2ch %dHz' % (nch, sr, rate)
+
+
+def wav_format(path):
+    try:
+        with wave.open(path, 'rb') as w:
+            return w.getnchannels(), w.getframerate(), w.getsampwidth()
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------
+# installation handling
+# --------------------------------------------------------------------------
+
+DLL = 'SharedResources.dll'
+STATE_DIRNAME = 'mtgo-audio-patch'
+
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1 << 20), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def find_app_dirs(prefix):
+    """Every installed MTGO application directory below a wine prefix."""
+    out = []
+    users = os.path.join(prefix, 'drive_c', 'users')
+    for root, dirs, files in os.walk(users):
+        if DLL in files and os.path.basename(root).startswith('mtgo..'):
+            out.append(root)
+            dirs[:] = []
+    return sorted(out)
+
+
+def state_dir_for(app_dir):
+    """Keep backups out of the ClickOnce directory, but on the same volume."""
+    local = os.path.dirname(app_dir)
+    while local and os.path.basename(local) not in ('Local', 'Apps'):
+        parent = os.path.dirname(local)
+        if parent == local:
+            break
+        local = parent
+    if os.path.basename(local) == 'Apps':
+        local = os.path.dirname(local)
+    if not local or os.path.basename(local) != 'Local':
+        local = os.path.dirname(app_dir)
+    return os.path.join(local, STATE_DIRNAME, os.path.basename(app_dir))
+
+
+def load_state(state_dir):
+    try:
+        with open(os.path.join(state_dir, 'state.json')) as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_state(state_dir, state):
+    os.makedirs(state_dir, exist_ok=True)
+    tmp = os.path.join(state_dir, 'state.json.tmp')
+    with open(tmp, 'w') as f:
+        json.dump(state, f, indent=1, sort_keys=True)
+    os.replace(tmp, os.path.join(state_dir, 'state.json'))
+
+
+def log(quiet, msg):
+    if not quiet:
+        sys.stdout.write('mtgo-audio-patch: %s\n' % msg)
+        sys.stdout.flush()
+
+
+def restore(app_dir, quiet=False):
+    state_dir = state_dir_for(app_dir)
+    state = load_state(state_dir)
+    backup = os.path.join(state_dir, DLL + '.orig')
+    n = 0
+    if os.path.exists(backup):
+        shutil.copy2(backup, os.path.join(app_dir, DLL))
+        log(quiet, 'restored %s' % os.path.join(app_dir, DLL))
+        n += 1
+    wav_backup = os.path.join(state_dir, 'wav')
+    for rel in state.get('wavs', []):
+        src = os.path.join(wav_backup, rel)
+        if os.path.exists(src):
+            shutil.copy2(src, os.path.join(app_dir, rel))
+            n += 1
+    save_state(state_dir, {})
+    log(quiet, 'restored %d file(s) in %s' % (n, app_dir))
+    return n
+
+
+def patch_app_dir(app_dir, force_volume=False, do_wavs=True, quiet=False,
+                  dry_run=False):
+    """Patch one MTGO installation.  Returns True when something was changed."""
+    dll = os.path.join(app_dir, DLL)
+    state_dir = state_dir_for(app_dir)
+    state = load_state(state_dir)
+    digest = sha256(dll)
+
+    if (state.get('version') == VERSION and state.get('patched_sha') == digest
+            and state.get('force_volume') == bool(force_volume)):
+        log(quiet, 'already patched: %s' % app_dir)
+        return False
+
+    with open(dll, 'rb') as f:
+        data = f.read()
+
+    if already_patched(Assembly(data)):
+        # patched by an older run (or by hand) but the state file is stale;
+        # fall back to the backup so patches always apply to pristine IL
+        backup = os.path.join(state_dir, DLL + '.orig')
+        if os.path.exists(backup):
+            with open(backup, 'rb') as f:
+                data = f.read()
+        else:
+            log(quiet, '%s is already patched but no backup exists; leaving it alone'
+                % dll)
+            return False
+
+    patched, msgs, rate = patch_assembly(data, force_volume=force_volume)
+    for m in msgs:
+        log(quiet, '  %s' % m)
+
+    wavs = []
+    if do_wavs:
+        audio = os.path.join(app_dir, 'Audio')
+        for root, _dirs, files in os.walk(audio):
+            for f in sorted(files):
+                if not f.lower().endswith('.wav'):
+                    continue
+                path = os.path.join(root, f)
+                fmt = wav_format(path)
+                if fmt is None or (fmt[0] == 2 and fmt[1] == rate and fmt[2] == 2):
+                    continue
+                wavs.append(os.path.relpath(path, app_dir))
+
+    if dry_run:
+        log(quiet, 'dry run: would patch %s and convert %d sound file(s)'
+            % (dll, len(wavs)))
+        return False
+
+    os.makedirs(state_dir, exist_ok=True)
+    backup = os.path.join(state_dir, DLL + '.orig')
+    if not os.path.exists(backup) or state.get('orig_sha') != sha256(backup):
+        shutil.copy2(dll, backup + '.tmp')
+        os.replace(backup + '.tmp', backup)
+
+    for rel in wavs:
+        src = os.path.join(app_dir, rel)
+        dst = os.path.join(state_dir, 'wav', rel)
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        if not os.path.exists(dst):
+            shutil.copy2(src, dst)
+        try:
+            tmp = src + '.tmp'
+            what = convert_wav(dst, tmp, rate)
+            os.replace(tmp, src)
+            log(quiet, '  %s: %s' % (rel, what))
+        except Exception as e:
+            log(quiet, '  %s: cannot convert (%s)' % (rel, e))
+
+    tmp = dll + '.tmp'
+    with open(tmp, 'wb') as f:
+        f.write(patched)
+    shutil.copystat(dll, tmp)
+    os.replace(tmp, dll)
+
+    save_state(state_dir, {
+        'version': VERSION,
+        'time': time.strftime('%Y-%m-%dT%H:%M:%S'),
+        'orig_sha': sha256(backup),
+        'patched_sha': sha256(dll),
+        'force_volume': bool(force_volume),
+        'sample_rate': rate,
+        'wavs': wavs,
+    })
+    log(quiet, 'patched %s' % dll)
+    return True
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description='Make MTGO audio work under Wine (see issue #217).')
+    p.add_argument('--prefix', default=os.environ.get('WINEPREFIX')
+                   or os.path.expanduser('~/.wine'),
+                   help='wine prefix to look into (default: $WINEPREFIX)')
+    p.add_argument('--app-dir', action='append', default=[],
+                   help='patch this MTGO application directory only')
+    p.add_argument('--force-volume', action='store_true',
+                   help="also force AudioManager.GetVolume() to 1.0, ignoring "
+                        "MTGO's own volume sliders")
+    p.add_argument('--no-wav', action='store_true',
+                   help='do not convert sound files that do not match the mixer')
+    p.add_argument('--restore', action='store_true',
+                   help='put the original files back')
+    p.add_argument('--dry-run', action='store_true', help='do not write anything')
+    p.add_argument('--dump', action='store_true',
+                   help='disassemble the patched methods (or those given as '
+                        'arguments) instead of patching anything')
+    p.add_argument('--dll', help='act on this SharedResources.dll (with --dump)')
+    p.add_argument('methods', nargs='*', metavar='Type::Method',
+                   help='methods to disassemble with --dump')
+    p.add_argument('--quiet', action='store_true')
+    args = p.parse_args(argv)
+
+    if args.dump:
+        dll = args.dll
+        if not dll:
+            dirs = args.app_dir or find_app_dirs(args.prefix)
+            if not dirs:
+                sys.stderr.write('mtgo-audio-patch: no MTGO installation found\n')
+                return 1
+            dll = os.path.join(dirs[-1], DLL)
+        sys.stdout.write('# %s\n' % dll)
+        with open(dll, 'rb') as f:
+            dump_methods(f.read(), args.methods or DUMP_DEFAULT)
+        return 0
+
+    if args.methods:
+        p.error('method names are only used with --dump')
+
+    app_dirs = args.app_dir or find_app_dirs(args.prefix)
+    if not app_dirs:
+        log(args.quiet, 'no MTGO installation found under %s (nothing to do)'
+            % args.prefix)
+        return 0
+
+    changed = 0
+    for app_dir in app_dirs:
+        try:
+            if args.restore:
+                restore(app_dir, quiet=args.quiet)
+            elif patch_app_dir(app_dir, force_volume=args.force_volume,
+                               do_wavs=not args.no_wav, quiet=args.quiet,
+                               dry_run=args.dry_run):
+                changed += 1
+        except (PatchError, ValueError) as e:
+            sys.stderr.write('mtgo-audio-patch: %s: %s\n' % (app_dir, e))
+            sys.stderr.write('mtgo-audio-patch: this MTGO version is not supported '
+                             'by the audio patch; sound may not work.\n')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/extra/mtgo.sh
+++ b/extra/mtgo.sh
@@ -2,14 +2,32 @@
 do_winecfg=false
 do_sound=false
 do_nosound=false
+do_audio_patch=true
+audio_patch_opts=""
 while [ -n "${1:-}" ]; do
    case "${1:-}" in
      --winecfg) do_winecfg=true ;;
      --sound) do_sound=true ;;
      --disable-sound) do_nosound=true ;;
+     --no-audio-patch) do_audio_patch=false ;;
+     --force-volume) audio_patch_opts="${audio_patch_opts} --force-volume" ;;
    esac
    shift
 done
+
+$do_sound || do_audio_patch=false
+
+# MTGO's own audio code does not work under wine; see
+# https://github.com/pauleve/docker-mtgo/issues/217
+audio_patch() {
+    $do_audio_patch || return 0
+    if ! command -v mtgo-audio-patch >/dev/null; then
+        echo "warning: mtgo-audio-patch is missing, sound will not work" >&2
+        do_audio_patch=false
+        return 0
+    fi
+    mtgo-audio-patch ${audio_patch_opts} "${@}"
+}
 
 if [ ! -d "${HOME}/.wine/drive_c/windows/syswow64" ]; then
     echo
@@ -67,11 +85,16 @@ workaround_dotnet
 
 setup="/opt/mtgo/mtgo.exe"
 
+audio_patch
+
 run wine ${setup}
 started=0
 s=6
 while :; do
     sleep $s
+    # the client updates itself: patch any freshly installed copy as well, so
+    # that sound keeps working after an update (from the next start on)
+    audio_patch --quiet
     winedbg --command "info proc"|grep MTGO.exe >/dev/null
     r=$?
     if [ $started -eq 0 ] && [ $r -eq 0 ]; then

--- a/run-mtgo
+++ b/run-mtgo
@@ -24,6 +24,8 @@ Options:
     -h, --help          display this message and exit
     --sound             enable sound (requires PulseAudio and Linux)
     --disable-sound     ensure that sound is disabled
+    --no-audio-patch    do not patch the MTGO client for wine audio support
+    --force-volume      ignore MTGO volume sliders (play everything at 100%)
     --cmd CMD           initial command (default: $cmd)
     --data-volume VOL   docker volume to store data (default: ${data})
     --reset             reset local data and docker volume
@@ -46,7 +48,7 @@ Options:
 lopts="dry-run,help,winecfg,shell,cmd:,name:"
 lopts="${lopts},bind:"
 lopts="${lopts},data-volume:,reset"
-lopts="${lopts},sound,disable-sound"
+lopts="${lopts},sound,disable-sound,no-audio-patch,force-volume"
 lopts="${lopts},test"
 lopts="${lopts},limit-cpus:"
 lopts="${lopts},no-tz"
@@ -78,6 +80,7 @@ eval set -- $args
 do_run=true
 do_reset=false
 do_test=false
+force_update=false
 
 mytz=${TZ:-}
 detect_tz=false
@@ -105,6 +108,8 @@ case "${1:-}" in
         do_sound=true ;;
     --disable-sound)
         [[ "$cmd" == "mtgo" ]] && cmdargs="${cmdargs} $1" ;;
+    --no-audio-patch|--force-volume)
+        [[ "$cmd" == "mtgo" ]] && cmdargs="${cmdargs} $1" ;;
     --limit-cpus) shift
         limit_cpus="$1" ;;
     --reset)
@@ -128,7 +133,8 @@ case "${1:-}" in
      --name) shift;
         name="$1" ;;
      --update)
-        do_update=true ;;
+        do_update=true
+        force_update=true ;;
      -e|-v|-u)
         opts="${opts} $1 $2" ;;
      --) shift ; shift
@@ -138,6 +144,8 @@ case "${1:-}" in
                 shift
             done
             image=$1
+            # a locally built image is not on the hub
+            do_update=$force_update
         fi ;;
 esac
 shift

--- a/sound/Dockerfile
+++ b/sound/Dockerfile
@@ -1,8 +1,10 @@
-FROM panard/mtgo:latest
+ARG BASE=panard/mtgo:latest
+FROM ${BASE}
 
 USER root
 
 RUN apt update && apt install -y --no-install-recommends \
+        python3-minimal \
         gstreamer1.0-plugins-good \
         gstreamer1.0-tools \
         gstreamer1.0-pulseaudio \

--- a/sound/local.Dockerfile
+++ b/sound/local.Dockerfile
@@ -1,0 +1,16 @@
+# Sound image built on top of an already available base image (by default the
+# one published on the hub), so that the wine audio support of issue #217 can be
+# used without rebuilding the whole wine/dotnet base.
+#
+#   make sound-local
+#   ./run-mtgo --sound panard/mtgo:sound-local
+#
+# This is the docker context of the repository, not of the sound/ directory.
+ARG BASE=panard/mtgo:sound-base
+FROM ${BASE}
+
+USER root
+COPY extra/mtgo.sh /usr/local/bin/mtgo
+COPY extra/mtgo-audio-patch.py /usr/local/bin/mtgo-audio-patch
+RUN chmod 755 /usr/local/bin/mtgo /usr/local/bin/mtgo-audio-patch
+USER wine

--- a/sound/tests/JitCheck.cs
+++ b/sound/tests/JitCheck.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Forces the CLR to JIT every method of MTGO's audio types.  Invalid IL shows
+// up here as InvalidProgramException / VerificationException.
+class JitCheck {
+    static string appdir;
+
+    static Assembly Resolve(object sender, ResolveEventArgs e) {
+        string n = new AssemblyName(e.Name).Name;
+        string p = Path.Combine(appdir, n + ".dll");
+        if (File.Exists(p)) return Assembly.LoadFrom(p);
+        return null;
+    }
+
+    static int Main(string[] args) {
+        string dll = args[0];
+        appdir = args[1];
+        AppDomain.CurrentDomain.AssemblyResolve += Resolve;
+        Assembly asm = Assembly.LoadFrom(dll);
+        Console.WriteLine("loaded " + asm.FullName);
+        string[] want = { "AudioManager", "SoundQueue", "ActiveSample", "SoundManager" };
+        int prepared = 0, failed = 0;
+        foreach (Type t in asm.GetTypes()) {
+            bool match = false;
+            foreach (string w in want) if (t.Name == w) match = true;
+            if (!match) continue;
+            Console.WriteLine("type " + t.FullName);
+            var flags = BindingFlags.Public | BindingFlags.NonPublic |
+                        BindingFlags.Instance | BindingFlags.Static |
+                        BindingFlags.DeclaredOnly;
+            foreach (MethodBase m in t.GetMethods(flags)) { if (Prepare(t, m)) prepared++; else failed++; }
+            foreach (MethodBase m in t.GetConstructors(flags)) { if (Prepare(t, m)) prepared++; else failed++; }
+        }
+        Console.WriteLine("JIT: " + prepared + " ok, " + failed + " failed");
+
+        // and actually call the two patched leaf methods
+        foreach (Type t in asm.GetTypes()) {
+            if (t.Name != "AudioManager") continue;
+            var f = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+            try {
+                Console.WriteLine("IsMuted() = " + t.GetMethod("IsMuted", f).Invoke(null, null));
+            } catch (Exception e) { Console.WriteLine("IsMuted() threw " + Inner(e)); failed++; }
+            try {
+                Console.WriteLine("GetWindowsVolume() = " + t.GetMethod("GetWindowsVolume", f).Invoke(null, null));
+            } catch (Exception e) { Console.WriteLine("GetWindowsVolume() threw " + Inner(e)); failed++; }
+        }
+        Console.WriteLine(failed == 0 ? "RESULT: OK" : "RESULT: FAILED");
+        return failed == 0 ? 0 : 1;
+    }
+
+    static string Inner(Exception e) {
+        while (e.InnerException != null) e = e.InnerException;
+        return e.GetType().Name + ": " + e.Message;
+    }
+
+    static bool Prepare(Type t, MethodBase m) {
+        if (m.IsAbstract || m.ContainsGenericParameters || t.ContainsGenericParameters)
+            return true;
+        try {
+            RuntimeHelpers.PrepareMethod(m.MethodHandle);
+            return true;
+        } catch (Exception e) {
+            Console.WriteLine("  JIT FAILED " + t.FullName + "." + m.Name + " -> " + Inner(e));
+            return false;
+        }
+    }
+}

--- a/sound/tests/PlayTest.cs
+++ b/sound/tests/PlayTest.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Threading;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+// Reproduces MTGO's SoundQueue/ActiveSample pipeline with NAudio, so the audio
+// stack can be exercised without logging into MTGO.
+//   mode "patched" : stereo mixer, no resampler   (what the patch produces)
+//   mode "orig"    : mono mixer + MediaFoundationResampler (what MTGO ships)
+class PlayTest {
+    static int Main(string[] args) {
+        string mode = args[0];
+        int channels = mode == "patched" ? 2 : 1;
+        var format = WaveFormat.CreateIeeeFloatWaveFormat(44100, channels);
+        var mixer = new MixingSampleProvider(format);
+        mixer.ReadFully = true;
+        var output = new WaveOutEvent();
+        output.DesiredLatency = 200;
+        try {
+            output.Init(new SampleToWaveProvider(mixer));
+            output.Play();
+            Console.WriteLine("output started: " + output.PlaybackState);
+        } catch (Exception e) {
+            Console.WriteLine("OUTPUT FAILED: " + e.GetType().Name + ": " + e.Message);
+            return 1;
+        }
+
+        int played = 0, failed = 0;
+        for (int i = 1; i < args.Length; i++) {
+            string path = args[i];
+            try {
+                byte[] data;
+                WaveFormat wf;
+                using (var r = new WaveFileReader(path)) {
+                    wf = r.WaveFormat;
+                    data = new byte[r.Length];
+                    r.Read(data, 0, data.Length);
+                }
+                var stream = new RawSourceWaveStream(data, 0, data.Length, wf);
+                IWaveProvider source = stream;
+                if (!wf.Equals(format) && mode != "patched") {
+                    source = new MediaFoundationResampler(stream, format);
+                }
+                mixer.AddMixerInput(new VolumeSampleProvider(source.ToSampleProvider()) { Volume = 1.0f });
+                Console.WriteLine("playing " + Path.GetFileName(path) + " [" + wf + "]");
+                played++;
+                Thread.Sleep(1200);
+            } catch (Exception e) {
+                Console.WriteLine("FAILED " + Path.GetFileName(path) + " -> " +
+                                  e.GetType().Name + ": " + e.Message);
+                failed++;
+            }
+        }
+        Thread.Sleep(1500);
+        output.Stop();
+        Console.WriteLine("played=" + played + " failed=" + failed);
+        Console.WriteLine(failed == 0 && played > 0 ? "RESULT: OK" : "RESULT: FAILED");
+        return failed == 0 && played > 0 ? 0 : 1;
+    }
+}

--- a/sound/tests/verify-audio.sh
+++ b/sound/tests/verify-audio.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Verify that MTGO audio works in the container, without logging into MTGO.
+#
+#   sound/tests/verify-audio.sh [IMAGE] [DOCKER_VOLUME]
+#
+# It works on a *copy* of the MTGO installation taken from the (read-only
+# mounted) docker volume, so the real installation is never touched, and:
+#
+#   1. compiles two C# harnesses with the csc.exe of the wine prefix;
+#   2. JITs MTGO's audio methods before and after the patch (invalid IL shows
+#      up here as InvalidProgramException);
+#   3. plays real MTGO sounds through MTGO's own NAudio pipeline into a
+#      throw-away PulseAudio sink and measures what comes out;
+#   4. replays the same thing the way MTGO ships it, which must fail.
+#
+# Requirements on the host: docker, pactl, parec, python3.
+set -u
+
+IMAGE="${1:-panard/mtgo:sound-local}"
+VOLUME="${2:-mtgo64-data-$USER}"
+NAME=mtgo-audio-verify
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+SINK=mtgoverify
+rc=0
+
+cleanup() {
+    docker rm -f $NAME >/dev/null 2>&1
+    local mod
+    mod=$(pactl list short modules 2>/dev/null | awk "/module-null-sink.*$SINK/ {print \$1}")
+    [ -n "$mod" ] && pactl unload-module "$mod" >/dev/null 2>&1
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+say() { echo; echo "=== $*"; }
+fail() { echo "FAIL: $*" >&2; rc=1; }
+
+say "container $IMAGE, volume $VOLUME (read only)"
+docker run -d --name $NAME \
+    -v "$VOLUME":/data:ro \
+    -v "$REPO/extra":/extra:ro \
+    -v "$REPO/sound/tests":/tests:ro \
+    -v "/run/user/$(id -u)/pulse/native:/run/user/1000/pulse/native" \
+    --entrypoint bash "$IMAGE" -c 'sleep infinity' >/dev/null || exit 1
+
+incontainer() { docker exec ${1:+-e PULSE_SINK=$SINK} $NAME bash -c "$2"; }
+
+say "copying the newest MTGO installation and compiling the harnesses"
+docker exec $NAME bash -c '
+set -e
+export WINEDEBUG=-all
+APPSRC=$(find /data -name SharedResources.dll -printf "%T@ %h\n" | sort -n | tail -1 | cut -d" " -f2-)
+echo "using $APPSRC"
+mkdir -p ~/app && cp -a "$APPSRC/." ~/app/ && cp /tests/*.cs ~/app/
+# start from the pristine client when this installation is already patched
+BACKUP=$(find /data -path "*mtgo-audio-patch*" -name "SharedResources.dll.orig" \
+    -newermt "1970-01-01" | grep -F "$(basename "$APPSRC")" | head -1)
+if [ -n "$BACKUP" ]; then echo "restoring pristine DLL from $BACKUP"; cp "$BACKUP" ~/app/SharedResources.dll; fi
+wine reg add "HKCU\Software\Wine\Drivers" /v Audio /t REG_SZ /d pulse /f >/dev/null 2>&1
+cd ~/app
+CSC=$HOME/.wine/drive_c/windows/Microsoft.NET/Framework64/v4.0.30319/csc.exe
+wine "$CSC" -nologo -out:JitCheck.exe JitCheck.cs 2>&1 | grep -i "error" || true
+wine "$CSC" -nologo -out:PlayTest.exe -r:NAudio.Core.dll -r:NAudio.WinMM.dll \
+    -r:NAudio.Wasapi.dll -r:netstandard.dll PlayTest.cs 2>&1 | grep -i "error" || true
+test -f JitCheck.exe -a -f PlayTest.exe' || { fail "could not build the harnesses"; exit 1; }
+
+jit() {
+    docker exec $NAME bash -c 'cd ~/app && WINEDEBUG=-all timeout 300 wine JitCheck.exe \
+        "$HOME/app/SharedResources.dll" "$HOME/app" 2>&1' | grep -v -e '^0[0-9a-f]*:err:'
+}
+
+say "unpatched client (baseline: valid IL, and audio effectively muted)"
+out=$(jit); echo "$out"
+echo "$out" | grep -q 'JIT: .* 0 failed' || fail "the unpatched client does not JIT"
+echo "$out" | grep -qE 'GetWindowsVolume\(\) = 0' \
+    || echo "note: wine reported a non-zero master volume here"
+
+say "applying the patch"
+docker exec $NAME python3 /extra/mtgo-audio-patch.py --app-dir /home/wine/app || fail "patch failed"
+
+say "patched client (must JIT and report a usable volume)"
+out=$(jit); echo "$out"
+echo "$out" | grep -q 'JIT: .* 0 failed' || fail "the patched client produces invalid IL"
+echo "$out" | grep -q 'GetWindowsVolume() = 1' || fail "GetWindowsVolume() is still muting"
+
+say "playing MTGO sounds into a throw-away sink"
+pactl load-module module-null-sink sink_name=$SINK \
+    sink_properties=device.description=$SINK >/dev/null || exit 1
+( timeout 20 parec -d $SINK.monitor --format=s16le --rate=44100 --channels=2 \
+    --file-format=raw > "$WORK/capture.raw" 2>/dev/null & )
+out=$(incontainer sink 'cd ~/app && WINEDEBUG=-all timeout 300 wine PlayTest.exe patched \
+    Audio/Alerts/GAME_BEGIN.wav Audio/Duel/WIN.wav Audio/Card/CARD_TAP_01.wav 2>&1' \
+    | grep -v -e '^0[0-9a-f]*:err:')
+echo "$out"
+echo "$out" | grep -q 'RESULT: OK' || fail "the patched pipeline could not play"
+wait 2>/dev/null
+sleep 1
+python3 - "$WORK/capture.raw" <<'PY' || fail "no audible samples reached PulseAudio"
+import array, math, sys
+a = array.array('h')
+a.frombytes(open(sys.argv[1], 'rb').read())
+n = len(a) or 1
+peak = max((abs(x) for x in a), default=0)
+rms = math.sqrt(sum(float(x) * x for x in a) / n)
+print('captured %.1f s, peak=%d rms=%.1f' % (len(a) / 2 / 44100, peak, rms))
+sys.exit(0 if peak > 1000 else 1)
+PY
+
+say "control: the pipeline as MTGO ships it (must fail under wine)"
+out=$(incontainer sink 'cd ~/app && WINEDEBUG=-all timeout 300 wine PlayTest.exe orig \
+    Audio/Alerts/GAME_BEGIN.wav 2>&1' | grep -v -e '^0[0-9a-f]*:err:')
+echo "$out"
+echo "$out" | grep -q 'RESULT: FAILED' \
+    || echo "note: the unpatched pipeline worked here, wine may have gained Media Foundation support"
+
+echo
+[ $rc -eq 0 ] && echo "ALL CHECKS PASSED" || echo "SOME CHECKS FAILED"
+exit $rc


### PR DESCRIPTION
Fixes the audio of `--sound`, which never actually produced sound: three independent failures in the client's own managed code (see #217).

## What is broken

* `AudioManager.GetWindowsVolume()` calls `waveOutGetVolume(IntPtr.Zero, ...)`, whose out parameter wine does not fill and whose return code MTGO ignores, so it returns 0. `PlaySound()` returns early when the windows volume is `<= 0`, which drops every sound before it reaches a queue. Measured in the container: `GetWindowsVolume() = 0` unpatched, `= 1` patched.
* `SoundQueue.ActiveSample..ctor` compares `WaveFormat` *references* to decide whether a sample needs resampling. They never match, so everything goes through `MediaFoundationResampler`, whose MFT is not registered in wine (`REGDB_E_CLASSNOTREG`). `PlaySoundSafe()` then latches `m_mediaPlayerNotAvailable`, disabling audio for the whole session.
* `AudioManager.IsMuted()` casts wine COM objects to `ISimpleAudioVolume`, which throws `InvalidCastException` on recent wine.

## What this does

`extra/mtgo-audio-patch.py` rewrites those methods in the client stored in the docker volume, switches the mixer to stereo (required once the resampler is bypassed, since `MixingSampleProvider` only accepts inputs already in its format) and converts the two shipped sound files that do not match that format (`Audio/Duel/WIN.wav` and `LOSE.wav`, mono 22050; the other 96 are stereo 44100).

* standard library only, no new image dependency beyond `python3-minimal` in the sound image;
* locates its targets through metadata and code patterns rather than file offsets, so it survives client updates, and refuses to touch the client when a pattern does not match, rather than corrupting it;
* originals are kept outside the ClickOnce directory, in `AppData/Local/mtgo-audio-patch`, and `--restore` puts them back;
* no patched binary is distributed: the script patches the user's own installation.

`extra/mtgo.sh` applies it before starting MTGO with `--sound`, and again in the watchdog loop, so a client that updates itself is patched for the next start. `run-mtgo` gains `--no-audio-patch` and `--force-volume` (`AudioManager.GetVolume()` is deliberately left alone by default so the in-game volume sliders keep working).

## Verification

`sound/tests/verify-audio.sh` proves audio works without logging into MTGO. It works on a copy taken from a read-only mount of the volume, JITs every method of `AudioManager`/`SoundQueue`/`ActiveSample` (invalid IL surfaces as `InvalidProgramException`), plays real MTGO sounds through MTGO's own NAudio pipeline into a throw-away PulseAudio sink and measures the result, and checks that the shipped pipeline still fails:

```
unpatched: JIT 44 ok, 0 failed   GetWindowsVolume() = 0
patched:   JIT 44 ok, 0 failed   GetWindowsVolume() = 1
capture:   4.8 s, peak=30999 rms=5045.9
control:   FAILED ... REGDB_E_CLASSNOTREG
ALL CHECKS PASSED
```

Verified on client builds 3.4.158.4691 and 3.4.157.4686, on an image based on `panard/mtgo:latest` (wine 9.8), with a real game session: four uncorked `float32le 2ch 44100Hz` streams named `Magic Online` on the host, and audible sound.

`SOUND.md` documents the mechanism, the evidence for each patch, the constraints that IL patching has to respect here, and how to re-derive the patch when a client release changes the code (`mtgo-audio-patch --dump` disassembles the methods involved).

## Also

* `make sound` builds the sound image on the image just built (`BASE` build arg) instead of always on `panard/mtgo:latest`;
* `make sound-local` builds the sound image with the patch on top of the published base, without a full rebuild;
* `run-mtgo` no longer pulls an image that was named explicitly on the command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnVdsPxWnESUFKgLH9T4W8